### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
             - main
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     build: 
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Kahera/Kahera.github.io/security/code-scanning/1](https://github.com/Kahera/Kahera.github.io/security/code-scanning/1)

To fix this issue, we will add a `permissions` block at the root of the workflow file to apply minimal permissions globally. This will ensure that all jobs, including `build`, inherit a secure default. Additionally, the `deploy` job already has explicit permissions defined, so it will override the global permissions where necessary. The global permissions will include `contents: read`, which is sufficient for the `build` job to check out the repository and install dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
